### PR TITLE
General updates to migration flow and content of 0003

### DIFF
--- a/arches_ciim_app/migrations/0001_initial.py
+++ b/arches_ciim_app/migrations/0001_initial.py
@@ -34,6 +34,8 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
+        # the last migration in 7.5.x
+        ("models", "9945_file_thumbnail_bin_file_thumbnail_text"),
     ]
 
     operations = [

--- a/arches_ciim_app/migrations/0002_add_plugin.py
+++ b/arches_ciim_app/migrations/0002_add_plugin.py
@@ -3,8 +3,6 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    initial = True
-
     dependencies = [
         ("arches_ciim_app", "0001_initial")
     ]

--- a/arches_ciim_app/migrations/0003_relatededitlogid_fk.py
+++ b/arches_ciim_app/migrations/0003_relatededitlogid_fk.py
@@ -2,10 +2,11 @@ from django.db.migrations.recorder import MigrationRecorder
 from django.db import migrations, models
 import django.db.models.deletion
 
+
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('arches_ciim_app', '0002_add_plugin'),
+        ("arches_ciim_app", "0002_add_plugin"),
     ]
 
     def update_all_relatededitlogids(apps, schema_editor):
@@ -17,7 +18,11 @@ class Migration(migrations.Migration):
 
         lres = LatestResourceEdit.objects.all()
         for lre in lres:
-            edit = EditLog.objects.order_by('resourceinstanceid', '-timestamp').distinct('resourceinstanceid').get(resourceinstanceid=lre.resourceinstanceid)
+            edit = (
+                EditLog.objects.order_by("resourceinstanceid", "-timestamp")
+                .distinct("resourceinstanceid")
+                .get(resourceinstanceid=lre.resourceinstanceid)
+            )
             lre.relatededitlogid = edit
             lre.save()
 
@@ -27,27 +32,24 @@ class Migration(migrations.Migration):
         """
         ...
 
-
-    # NOTE: this is a very hacky method to get the reverse migration to work.  
-    # Reversing migration with "models.editlog" string produces error `ValueError: Related model 'models.editlog' cannot be resolved` ...
-    # ... as for some unknown reason django can't see the arches models app in reverse.  In reverse if we have the model name as ...
-    # ... arches_ciim_app.latestresourceedit then the migration can reverse successfully, despite not looking at the correct linked table (editlog)
-    applied_migrations = MigrationRecorder.Migration.objects.filter(app="arches_ciim_app").values_list('name', flat=True)
-    if "0003_relatededitlogid_fk" in applied_migrations:
-        model_name = "arches_ciim_app.latestresourceedit"
-    else:
-        model_name = "models.editlog"
-
     operations = [
         migrations.RenameField(
-            model_name='latestresourceedit',
-            old_name='editlogid',
-            new_name='latestresourceeditid',
+            model_name="latestresourceedit",
+            old_name="editlogid",
+            new_name="latestresourceeditid",
         ),
         migrations.AddField(
-            model_name='latestresourceedit',
-            name='relatededitlogid',
-        field=models.OneToOneField(blank=True, db_column='relatededitlogid', null=True, on_delete=django.db.models.deletion.PROTECT, to=model_name),
+            model_name="latestresourceedit",
+            name="relatededitlogid",
+            field=models.OneToOneField(
+                blank=True,
+                db_column="relatededitlogid",
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                to="models.editlog",
+            ),
         ),
-        migrations.RunPython(update_all_relatededitlogids, remove_all_relatededitlogids)
+        migrations.RunPython(
+            update_all_relatededitlogids, remove_all_relatededitlogids
+        ),
     ]


### PR DESCRIPTION
Closes #9 

- Previously all migrations had `initial = True` which was problematic for various reasons
- I can't exactly remember the reason why the hacky fix applied in https://github.com/k-int/arches-ciim-app/pull/2/commits/a02b1ff08f1ef7caef5f2859ec831a71831ca7e3 was required, but it doesn't seem relevant now? Migrating forwards from 0002 and reverse from 0003 works as expected, with the new onetoone column (including contents) added and removed, respectively.