### PR TITLE
Add permissions checks to resource changes api

### DIFF
--- a/arches_ciim_app/views/ciim.py
+++ b/arches_ciim_app/views/ciim.py
@@ -16,9 +16,20 @@ from arches.app.models.models import Concept as modelConcept
 from arches.app.models.concept import Concept
 from arches.app.utils.skos import SKOSWriter, SKOSReader
 
+from arches.app.utils.permission_backend import (
+    user_can_read_resource,
+    user_can_edit_resource,
+    user_can_delete_resource,
+    user_can_read_concepts,
+    user_is_resource_reviewer,
+    get_restricted_instances,
+    check_resource_instance_permissions,
+    get_nodegroups_by_perm,
+)
+
 from arches import __version__
 
-#Decorators
+# Decorators
 def timer(func):
     '''
     Description:
@@ -38,10 +49,10 @@ def timer(func):
 class ChangesView(View):
 
     def get(self, request):
-        #Timer start
+        # Timer start
         start_time = time()
 
-        #Functions
+        # Functions
         @timer
         def get_data(from_date, to_date, per_page, page):
             '''
@@ -50,15 +61,26 @@ class ChangesView(View):
             Returns:
             :tuple: Where [0] contains all ID's, [1] total of all ID's, [2] number of pages
             '''
-            #Get all edits within time range
-            edits = LatestResourceEdit.objects.filter(timestamp__range=(from_date, to_date)).order_by('timestamp')
+            # Get all edits within time range
+            edits = (
+                LatestResourceEdit.objects
+                .filter(timestamp__range=(from_date, to_date))
+                .order_by("timestamp")
+                .exclude(resourceinstanceid=settings.SYSTEM_SETTINGS_RESOURCE_ID)
+            )
 
-            #Remove settings changes
-            if settings.SYSTEM_SETTINGS_RESOURCE_ID in [edit.resourceinstanceid for edit in edits]:
-                edits = edits.exclude(resourceinstanceid=settings.SYSTEM_SETTINGS_RESOURCE_ID)
+            # Check resource permissions
+            filtered_edits = [
+                edit for edit in edits
+                if user_can_read_resource(
+                    user=request.user, resourceid=edit.resourceinstanceid
+                )
+            ]
+
+            edits = filtered_edits
 
             total_resources = len(edits)
-            #Paginate results
+            # Paginate results
             no_pages = math.ceil(total_resources/per_page)
             edits = edits[(page-1)*per_page:page*per_page]
 
@@ -87,28 +109,27 @@ class ChangesView(View):
                 else:
                     data.append({'modified':edit.timestamp,'resourceinstance_id':resourceid, 'tiles':None})
 
-
             return (data,)
 
-        #Process input
-        #Dates
+        # Process input
+        # Dates
         from_date = request.GET.get('from')
         to_date = request.GET.get('to')
         from_date = datetime.strptime(from_date, '%d-%m-%YT%H:%M:%SZ')
         to_date = datetime.strptime(to_date, '%d-%m-%YT%H:%M:%SZ')
 
-        #Pages
+        # Pages
         per_page = int(request.GET.get('perPage'))
         page = int(request.GET.get('page'))
 
-        #Data
+        # Data
         db_data = get_data(from_date, to_date, per_page, page)
 
         json_data = download_data(db_data[0])
 
         end_time = time()
 
-        #Dictionaries
+        # Dictionaries
 
         time_elapsed = {
             'total' : db_data[-1]  + json_data[-1],

--- a/arches_ciim_app/views/ciim.py
+++ b/arches_ciim_app/views/ciim.py
@@ -10,6 +10,7 @@ from arches.app.models.system_settings import settings
 from arches.app.utils.betterJSONSerializer import JSONSerializer
 
 from arches.app.models.resource import Resource
+from arches.app.models.tile import Tile
 from arches_ciim_app.models import LatestResourceEdit
 
 from arches.app.models.models import Concept as modelConcept
@@ -77,6 +78,10 @@ class ChangesView(View):
                 )
             ]
 
+            permitted_nodegroupids = get_nodegroups_by_perm(
+                request.user, "models.read_nodegroup"
+            )
+
             edits = filtered_edits
 
             total_resources = len(edits)
@@ -84,10 +89,10 @@ class ChangesView(View):
             no_pages = math.ceil(total_resources/per_page)
             edits = edits[(page-1)*per_page:page*per_page]
 
-            return (edits, total_resources, no_pages)
+            return (edits, permitted_nodegroupids, no_pages)
 
         @timer
-        def download_data(edits):
+        def download_data(edits, permitted_nodegroupids):
             '''
             Get all data as json
             Returns:
@@ -99,12 +104,13 @@ class ChangesView(View):
                 resourceid=edit.resourceinstanceid
                 if Resource.objects.filter(pk=resourceid).exists():
                     resource = Resource.objects.get(pk=resourceid)
-                    resource.load_tiles()
+                    # Rather than load_tiles(), we fetch tiles separately and check permitted_nodegroups
+                    tile = Tile.objects.filter(resourceinstance_id=resourceid, nodegroup_id__in=permitted_nodegroupids)
+                    resource.tiles.extend(tile)
 
                     if not(len(resource.tiles) == 1 and not resource.tiles[0].data):
                         resource_json= {'modified':edit.timestamp.strftime('%d-%m-%YT%H:%M:%SZ')}
                         resource_json.update(JSONSerializer().serializeToPython(resource))
-
                         data.append(resource_json)
                 else:
                     data.append({'modified':edit.timestamp,'resourceinstance_id':resourceid, 'tiles':None})
@@ -124,8 +130,7 @@ class ChangesView(View):
 
         # Data
         db_data = get_data(from_date, to_date, per_page, page)
-
-        json_data = download_data(db_data[0])
+        json_data = download_data(db_data[0], db_data[1])
 
         end_time = time()
 
@@ -140,7 +145,7 @@ class ChangesView(View):
         metadata = {
             'from': from_date,
             'to': to_date,
-            'totalNumberOfResources': db_data[1],
+            'totalNumberOfResources': len(db_data[0]),
             'perPage': per_page,
             'page': page,
             'numberOfPages': db_data[2],


### PR DESCRIPTION
Adds checks for whether a user can read a resource, and the permitted nodegroups when displaying data in the API view