### PR TITLE
Fix 0002 migration for 7.6 compatibility

### DIFF
--- a/arches_ciim_app/migrations/0002_add_plugin.py
+++ b/arches_ciim_app/migrations/0002_add_plugin.py
@@ -5,25 +5,29 @@ class Migration(migrations.Migration):
 
     dependencies = [("arches_ciim_app", "0001_initial")]
 
-    forward = """
-        INSERT INTO plugins (
-            pluginid, name, icon, component, componentname, config, slug, sortorder)
-        VALUES (
-            'eb53e958-9ddf-40a9-8acd-da2b27df8340',
-            'CIIM Integration Dashboard',
-            'fa fa-link',
-            'views/components/plugins/ciim_integration_dashboard',
-            'ciim_integration_dashboard', 
-            '{"show": true, "is_workflow": false, "description": ""}',
-            'ciim_integration_dashboard',
-            '1'
-        );
-        """
+    def add_plugin(apps, schema_editor):
+        Plugin = apps.get_model("models", "Plugin")
 
-    reverse = """
-        DELETE FROM plugins where pluginid = 'eb53e958-9ddf-40a9-8acd-da2b27df8340';
-        """
+        if not Plugin.objects.filter(
+            pk="eb53e958-9ddf-40a9-8acd-da2b27df8340"
+        ).exists():
+            Plugin.objects.update_or_create(
+                pluginid="eb53e958-9ddf-40a9-8acd-da2b27df8340",
+                name="CIIM Integration Dashboard",
+                icon="fa fa-link",
+                component="views/components/plugins/ciim_integration_dashboard",
+                componentname="ciim_integration_dashboard",
+                slug="ciim_integration_dashboard",
+                config={"show": True, "is_workflow": True, "description": ""},
+                sortorder=1,
+            )
+
+    def remove_plugin(apps, schema_editor):
+        Plugin = apps.get_model("models", "Plugin")
+
+        for plugin in Plugin.objects.filter(pk="eb53e958-9ddf-40a9-8acd-da2b27df8340"):
+            plugin.delete()
 
     operations = [
-        migrations.RunSQL(forward, reverse),
+        migrations.RunPython(add_plugin, remove_plugin),
     ]


### PR DESCRIPTION
Closes #19 

This changes the sql code to python code which is validated and corrected via Arches, successfully converting the name string to i18n on new projects running 7.6.

A new migration may still be required to fix plugins instantiated on 7.5 if Arches does not.